### PR TITLE
Remove Travis CI deploy configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,3 @@ jobs:
   include:
     - stage: test
       script: shellcheck --exclude SC2086 ./bin/*
-    - stage: deploy
-      script: echo "Deploying to GitHub releases ..."
-      deploy:
-        provider: releases
-        api_key: $GITHUB_OAUTH_TOKEN
-        skip_cleanup: true
-        on:
-          tags: true


### PR DESCRIPTION
Remove the `deploy` job from Travis CI configuration.